### PR TITLE
add labeling of possible duplicate and extra roots

### DIFF
--- a/yroots/ChebyshevSubdivisionSolver.py
+++ b/yroots/ChebyshevSubdivisionSolver.py
@@ -1133,9 +1133,6 @@ def solvePolyRecursive(Ms, trackedInterval, errors, solverOptions):
         interval
     """
     #TODO: Check if trackedInterval.interval has width 0 in some dimension, in which case we should get rid of that dimension.
-#     if not (trackedInterval.finalStep or np.array([-0.8800495974172176, -0.44790195469433863]) in trackedInterval):
-#         return [], []
-#     print("Start:", trackedInterval.interval, Ms)
     
     #If the interval is a point, return it
     if trackedInterval.isPoint():

--- a/yroots/Combined_Solver.py
+++ b/yroots/Combined_Solver.py
@@ -63,8 +63,11 @@ def degree_guesser(funcs,guess_degs,default_deg):
                 #problem: this includes rational polynomials, maybe include "/" in the string search
                 #don't update guess_degs[i]
             else:
-                expr = sy.sympify(expr)
-                guess_degs[i] = max(sy.degree_list(expr))
+                try:
+                    expr = sy.sympify(expr)
+                    guess_degs[i] = max(sy.degree_list(expr))
+                except:
+                    pass
     return [is_lambda_poly, is_routine, is_lambda, guess_degs]
 
 def solve(funcs,a=[],b=[],guess_degs=None,max_deg_edit=None,rescale=False,rel_approx_tol=1.e-15, abs_approx_tol=1.e-12, 


### PR DESCRIPTION
When the code is on the final step where it is zooming in without error, now always zooms into a point. Labels the point as a possible extra if it would have gotten thrown out if it wasn't the final step, and as a possible duplicate if we zoom in to multiple points in the same final interval.